### PR TITLE
Fix eslint errors, except `no-multi-spaces`

### DIFF
--- a/resources/js/customize-preview/custom-header.js
+++ b/resources/js/customize-preview/custom-header.js
@@ -4,31 +4,32 @@
  * This file handles the JavaScript for the live preview of the `custom-header`
  * feature in the customizer.
  *
+ * [Mythic Theme](https://themehybrid.com/themes/mythic)
+ *
  * @package   Mythic
  * @author    Justin Tadlock <justintadlock@gmail.com>
  * @copyright 2018 Justin Tadlock
  * @license   https://www.gnu.org/licenses/gpl-2.0.html GPL-2.0-or-later
- * @link      https://themehybrid.com/themes/mythic
  */
 
 // Site title.
-wp.customize( 'blogname', value => {
-	value.bind( to => {
+wp.customize( 'blogname', ( value ) => {
+	value.bind( ( to ) => {
 		document.querySelector( '.app-header__title-link' ).textContent = to;
 	} );
 } );
 
 // Site description.
-wp.customize( 'blogdescription', value => {
-	value.bind( to => {
+wp.customize( 'blogdescription', ( value ) => {
+	value.bind( ( to ) => {
 		document.querySelector( '.app-header__description' ).textContent = to;
 	} );
 } );
 
 // Header text color.
-wp.customize( 'header_textcolor', value => {
-	value.bind( to => {
-		var headerItems = document.querySelectorAll(
+wp.customize( 'header_textcolor', ( value ) => {
+	value.bind( ( to ) => {
+		const headerItems = document.querySelectorAll(
 			'.app-header__title-link, .app-header__description'
 		);
 


### PR DESCRIPTION
@link does not exist, I stumbled on some VSCODE issue (I use Atom) that said that it handled markdown so I just converted the link to MD

You may want to allow `no-multi-spaces` in eslint conf the WP coding standards for PHP actually require you do align spaces but in JS is disallowed, seems strange to me.